### PR TITLE
fix array out-of-bounds in ADM and Multitouch on Linux builds

### DIFF
--- a/hw/arm/ipod_touch_adm.c
+++ b/hw/arm/ipod_touch_adm.c
@@ -75,7 +75,7 @@ static void ipod_touch_adm_write(void *opaque, hwaddr offset, uint64_t value, un
                         s->nand_state->reading_multiple_pages = true;
                         buf = malloc(2);
                         address_space_read(&s->downstream_as, s->data2_sec_addr + 0x1104 + 0x28, MEMTXATTRS_UNSPECIFIED, buf, 2);
-                        num_pages = *buf;
+                        num_pages = *(uint16_t*)buf;
                         num_pages = ( (((num_pages) >> 8) & 0x00FF) | (((num_pages) << 8) & 0xFF00) ); // swap endianness
                         //printf("Reading %d pages at once, ", num_pages);
 
@@ -112,12 +112,12 @@ static void ipod_touch_adm_write(void *opaque, hwaddr offset, uint64_t value, un
                         s->nand_state->reading_multiple_pages = false;
                         buf = malloc(2);
                         address_space_read(&s->downstream_as, s->data2_sec_addr + 0x1104 + 0x28, MEMTXATTRS_UNSPECIFIED, buf, 2);
-                        num_pages = *buf;
+                        num_pages = *(uint16_t*)buf;
                         num_pages = ( (((num_pages) >> 8) & 0x00FF) | (((num_pages) << 8) & 0xFF00) ); // swap endianness
                         if(num_pages == 1) {
                             // TODO this can probably be refactored to re-use the logic to read multiple pages!
                             address_space_read(&s->downstream_as, s->data2_sec_addr + 0x1104 + 0x44, MEMTXATTRS_UNSPECIFIED, buf, 1);
-                            bank = *buf;
+                            bank = *(uint8_t*)buf;
 
                             buf = malloc(4);
                             address_space_read(&s->downstream_as, s->data2_sec_addr + 0x1104 + 0x244, MEMTXATTRS_UNSPECIFIED, buf, 4);
@@ -154,7 +154,7 @@ static void ipod_touch_adm_write(void *opaque, hwaddr offset, uint64_t value, un
 
                                 buf = malloc(1);
                                 address_space_read(&s->downstream_as, s->data2_sec_addr + 0x1104 + 0x44 + i, MEMTXATTRS_UNSPECIFIED, buf, 1);
-                                bank = *buf;
+                                bank = *(uint8_t*)buf;
                                 // printf("Page: %d, bank: %d\n", page, bank);
 
                                 s->nand_state->pages_to_read[i] = page;
@@ -175,7 +175,7 @@ static void ipod_touch_adm_write(void *opaque, hwaddr offset, uint64_t value, un
                         // writing a page
                         buf = malloc(1);
                         address_space_read(&s->downstream_as, s->data2_sec_addr + 0x1104 + 0x44, MEMTXATTRS_UNSPECIFIED, buf, 1);
-                        bank = *buf;
+                        bank = *(uint8_t*)buf;
 
                         buf = malloc(4);
                         address_space_read(&s->downstream_as, s->data2_sec_addr + 0x1104 + 0x244, MEMTXATTRS_UNSPECIFIED, buf, 4);

--- a/hw/arm/ipod_touch_multitouch.c
+++ b/hw/arm/ipod_touch_multitouch.c
@@ -221,7 +221,7 @@ static uint32_t ipod_touch_multitouch_transfer(SSIPeripheral *dev, uint32_t valu
         uint32_t data_len = (s->in_buffer[2] << 10) | (s->in_buffer[3] << 2) + 5;
         // extend the lengths of the in/out buffers
         free(s->in_buffer);
-        s->in_buffer = malloc(data_len);
+        s->in_buffer = malloc(data_len + 0x10);
 
         free(s->out_buffer);
         s->out_buffer = malloc(data_len);


### PR DESCRIPTION
on Linux builds, I kept getting crashes in various `malloc`s as described in #12. I was able to track down the problem with the compiler warnings mentioned in #12 as well as configuring the build with the following:

```
../configure --enable-sdl --disable-cocoa --target-list=arm-softmmu --disable-capstone --disable-pie --disable-slirp --disable-werror --extra-cflags="-fno-omit-frame-pointer -fsanitize=address -g" --extra-ldflags='-lcrypto -fsanitize=address'
```

which dumped stack traces for where the heap corruption was occurring. As for the Multitouch issue (a similar problem), I just added `0x10` bytes to the allocation and it seemed to work. I also compiled this on macOS following your instructions and it still works there, too.

Closes #12 