### PR TITLE
Update ipod_touch_fmss.c

### DIFF
--- a/hw/arm/ipod_touch_fmss.c
+++ b/hw/arm/ipod_touch_fmss.c
@@ -31,7 +31,7 @@ static void dump_registers(IPodTouchFMSSState *s) {
 static void read_nand_pages(IPodTouchFMSSState *s)
 {
     // boot args
-    char *boot_args = "kextlog=0xfff debug=0x8 cpus=1 rd=disk0s1 serial=1 pmu-debug=0x1 io=0xffff8fff debug-usb=0xffffffff";
+    const char *boot_args = "kextlog=0xfff debug=0x8 cpus=1 rd=disk0s1 serial=1 pmu-debug=0x1 io=0xffff8fff debug-usb=0xffffffff"; // if not const then overwritten
     cpu_physical_memory_write(0x0ff2a584, boot_args, strlen(boot_args));
 
     int page_out_buf_ind = 0;


### PR DESCRIPTION
fix issue where boot arguments were not actually updating when recompiling qemu; this became a huge nuisance and I spent some time trying to track down why only to find out that the string wasn't a constant and it should have been.