### PR TITLE
Fix the configure command for apple silicon macs in RUNNING.MD

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -10,7 +10,10 @@ Compile QEMU by running the following commands from the root directory:
 ```
 mkdir build
 cd build
+# On Intel Macs
 ../configure --enable-sdl --disable-cocoa --target-list=arm-softmmu --disable-capstone --disable-pie --disable-slirp --extra-cflags=-I/usr/local/opt/openssl@3/include --extra-ldflags='-L/usr/local/opt/openssl@3/lib -lcrypto'
+# On Apple Silicon Macs
+../configure --enable-sdl --disable-cocoa --target-list=arm-softmmu --disable-capstone --disable-pie --disable-slirp --extra-cflags=-I/opt/homebrew/opt/openssl@3/include --extra-ldflags='-L/opt/homebrew/opt/openssl@3/lib -lcrypto'
 make
 ```
 


### PR DESCRIPTION
Homebrew on Apple Silicon uses `/opt/homebrew` instead of `/usr/local`
This pull request adds a second configure command for Apple Silicon Macs.