### PR TITLE
Check if Bootrom/NOR/NAND files exist before attempting to use

### DIFF
--- a/hw/arm/ipod_touch_2g.c
+++ b/hw/arm/ipod_touch_2g.c
@@ -110,6 +110,12 @@ static char *ipod_touch_get_bootrom_path(Object *obj, Error **errp)
 
 static void ipod_touch_set_bootrom_path(Object *obj, const char *value, Error **errp)
 {
+    gboolean bootrom_exists = g_file_test(value, G_FILE_TEST_EXISTS);
+    if(!bootrom_exists) {
+        error_report("bootrom at path \"%s\" must exist", value);
+        exit(1);
+    }
+    
     IPodTouchMachineState *nms = IPOD_TOUCH_MACHINE(obj);
     g_strlcpy(nms->bootrom_path, value, sizeof(nms->bootrom_path));
 }
@@ -122,6 +128,12 @@ static char *ipod_touch_get_nor_path(Object *obj, Error **errp)
 
 static void ipod_touch_set_nor_path(Object *obj, const char *value, Error **errp)
 {
+    gboolean nor_exists = g_file_test(value, G_FILE_TEST_EXISTS);
+    if(!nor_exists) {
+        error_report("NOR at path \"%s\" must exist", value);
+        exit(1);
+    }
+
     IPodTouchMachineState *nms = IPOD_TOUCH_MACHINE(obj);
     g_strlcpy(nms->nor_path, value, sizeof(nms->nor_path));
 }
@@ -134,6 +146,12 @@ static char *ipod_touch_get_nand_path(Object *obj, Error **errp)
 
 static void ipod_touch_set_nand_path(Object *obj, const char *value, Error **errp)
 {
+    gboolean nand_exists = g_file_test(value, G_FILE_TEST_EXISTS & G_FILE_TEST_IS_DIR);
+    if(!nand_exists) {
+        error_report("NAND at path \"%s\" must be a directory", value);
+        exit(1);
+    }
+    
     IPodTouchMachineState *nms = IPOD_TOUCH_MACHINE(obj);
     g_strlcpy(nms->nand_path, value, sizeof(nms->nand_path));
 }

--- a/hw/arm/ipod_touch_2g.c
+++ b/hw/arm/ipod_touch_2g.c
@@ -146,7 +146,7 @@ static char *ipod_touch_get_nand_path(Object *obj, Error **errp)
 
 static void ipod_touch_set_nand_path(Object *obj, const char *value, Error **errp)
 {
-    gboolean nand_exists = g_file_test(value, G_FILE_TEST_EXISTS & G_FILE_TEST_IS_DIR);
+    gboolean nand_exists = g_file_test(value, G_FILE_TEST_IS_DIR);
     if(!nand_exists) {
         error_report("NAND at path \"%s\" must be a directory", value);
         exit(1);


### PR DESCRIPTION
This PR adds a simple check to each path setter in the `ipod_touch_2g` machine type. Will close #85.

If the file is missing *(or in the case of NAND, it will also check if it is a directory)* when setting the property then it will catch that issue here, instead of continuing execution and causing a null pointer reference.

Tested under Linux.